### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Gemfile.lock
 /maintenance-tasks/build/
 /android/.cxx/Debug/5k2s1t1p/x86/
 /ffmpeg/ffmpeg-kit-android-lib/.cxx/Debug/
+/android/.idea/


### PR DESCRIPTION
for those working with android studio or intellj, a .idea is auto generated when you start a new project. so if you trying to fork this project, and use android studio or intellij to open it, this will result in android been unable to recognize the project.
so ignoring this dir, each IDE can create its own .idea